### PR TITLE
Remove phpstan-ignore comments from test callbacks

### DIFF
--- a/tests/DsTest.php
+++ b/tests/DsTest.php
@@ -64,7 +64,6 @@ final class DsTest extends TestCase
 
         $map = mappedQueuesFromIterable(
             $iterableFactory(),
-            /** @phpstan-ignore argument.type */
             static fn (int $key, string $value) => new Pair($key * 2, $value . '_'),
         );
 
@@ -90,7 +89,6 @@ final class DsTest extends TestCase
 
         $map = mappedSetsFromIterable(
             $iterableFactory(),
-            /** @phpstan-ignore argument.type */
             static fn (int $key, string $value) => new Pair($key * 2, $value . '_'),
         );
 


### PR DESCRIPTION
This PR removes unnecessary PHPStan ignore comments from test code.

## Summary
Cleaned up PHPStan suppression comments that are no longer needed in the test suite.

## Key Changes
- Removed `/** @phpstan-ignore argument.type */` comment from the callback in `testMappedQueuesFromIterable()`
- Removed `/** @phpstan-ignore argument.type */` comment from the callback in `testMappedSetsFromIterable()`

These comments were suppressing type-checking warnings that are apparently no longer triggered, indicating that either the type definitions have been improved or PHPStan's analysis has been refined to better understand the code's intent.

https://claude.ai/code/session_01V5NrkKNz8sCSpgsHupvGhL