### PR TITLE
Upgrade ramsey/composer-install action from v1 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           ini-values: "zend.assertions=1"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -25,7 +25,7 @@ jobs:
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
 
       - name: "Run PHP_CodeSniffer"
         run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"
@@ -47,7 +47,7 @@ jobs:
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
 
       - name: "Run PHP_CodeSniffer"
         run: "composer normalize --dry-run"

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -26,7 +26,7 @@ jobs:
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
 
       - name: Run Infection
         run: vendor/bin/infection --threads=$(nproc)

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
 
       - name: "Run a static analysis with phpstan/phpstan"
         run: "vendor/bin/phpstan --error-format=checkstyle | cs2pr"
@@ -47,7 +47,7 @@ jobs:
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
 
       - name: "Run Composer Unused"
         run: "vendor/bin/composer-dependency-analyser"


### PR DESCRIPTION
## Summary
This pull request upgrades the `ramsey/composer-install` GitHub Action from version 1 to version 3 across all CI/CD workflows.

## Key Changes
- Updated `ramsey/composer-install` action version from `v1` to `v3` in:
  - `.github/workflows/coding-standards.yml` (2 occurrences)
  - `.github/workflows/static-analysis.yml` (2 occurrences)
  - `.github/workflows/ci.yml` (1 occurrence)
  - `.github/workflows/infection.yml` (1 occurrence)

## Details
This upgrade ensures the project uses the latest version of the Composer installation action, which includes improvements, bug fixes, and better compatibility with modern PHP and Composer versions. The action is used consistently across all workflow jobs that require Composer dependency installation.

https://claude.ai/code/session_01EmBxxfe3eMHRAJDiQGsGyV