### PR TITLE
Add mappedMapsFromIterable function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ $map = mapFromEntries([
 assert($map->get('foo') === 'bar');
 ```
 
+### `mappedMapsFromIterable()`
+
+Groups an iterable into a `Map<K, Map<KInner, V>>` using a mapper that returns nested `Pair`s.
+
+```php
+use Ds\Pair;
+use function Cdn77\Functions\mappedMapsFromIterable;
+
+$map = mappedMapsFromIterable(
+    ['a' => 1, 'b' => 2, 'c' => 1],
+    static fn (string $key, int $value) => new Pair($value, new Pair($key, $key . '_')),
+);
+
+assert($map->get(1)->get('a') === 'a_');
+assert($map->get(1)->get('c') === 'c_');
+assert($map->get(2)->get('b') === 'b_');
+```
+
 ## Iterable
 
 ### find()

--- a/src/ds.php
+++ b/src/ds.php
@@ -87,6 +87,38 @@ function mappedQueuesFromIterable(iterable $iterable, callable $mapper): Map
 
 /**
  * @param iterable<K, V> $iterable
+ * @param callable(K, V): Pair<KReturn, Pair<KInner, VReturn>> $mapper
+ *
+ * @return Map<KReturn, Map<KInner, VReturn>>
+ *
+ * @template K
+ * @template V
+ * @template KReturn
+ * @template KInner
+ * @template VReturn
+ */
+function mappedMapsFromIterable(iterable $iterable, callable $mapper): Map
+{
+    /** @var Map<KReturn, Map<KInner, VReturn>> $map */
+    $map = new Map();
+
+    foreach ($iterable as $key => $value) {
+        $keyValue = $mapper($key, $value);
+        $innerMap = $map->get($keyValue->key, null);
+        if ($innerMap === null) {
+            /** @var Map<KInner, VReturn> $innerMap */
+            $innerMap = new Map();
+            $map->put($keyValue->key, $innerMap);
+        }
+
+        $innerMap->put($keyValue->value->key, $keyValue->value->value);
+    }
+
+    return $map;
+}
+
+/**
+ * @param iterable<K, V> $iterable
  * @param callable(K, V): Pair<KReturn, VReturn> $mapper
  *
  * @return Map<KReturn, Set<VReturn>>

--- a/tests/DsTest.php
+++ b/tests/DsTest.php
@@ -11,12 +11,14 @@ use PHPUnit\Framework\TestCase;
 
 use function Cdn77\Functions\mapFromEntries;
 use function Cdn77\Functions\mapFromIterable;
+use function Cdn77\Functions\mappedMapsFromIterable;
 use function Cdn77\Functions\mappedQueuesFromIterable;
 use function Cdn77\Functions\mappedSetsFromIterable;
 use function Cdn77\Functions\setFromIterable;
 use function Cdn77\Functions\vectorFromIterable;
 
 #[CoversFunction('Cdn77\Functions\mapFromIterable')]
+#[CoversFunction('Cdn77\Functions\mappedMapsFromIterable')]
 #[CoversFunction('Cdn77\Functions\mappedQueuesFromIterable')]
 #[CoversFunction('Cdn77\Functions\mappedSetsFromIterable')]
 #[CoversFunction('Cdn77\Functions\setFromIterable')]
@@ -51,6 +53,33 @@ final class DsTest extends TestCase
         self::assertCount(2, $map);
         self::assertNull($map->get(1, null));
         self::assertFalse($map->get(4));
+    }
+
+    public function testMappedMapsFromIterable(): void
+    {
+        $iterableFactory = static function (): Generator {
+            yield 1 => 'a';
+            yield 1 => 'b';
+            yield 2 => 'c';
+            yield 2 => 'd';
+        };
+
+        $map = mappedMapsFromIterable(
+            $iterableFactory(),
+            static fn (int $key, string $value) => new Pair($key * 2, new Pair($value, $value . '_')),
+        );
+
+        self::assertCount(2, $map);
+
+        $innerAt2 = $map->get(2);
+        self::assertCount(2, $innerAt2);
+        self::assertSame('a_', $innerAt2->get('a'));
+        self::assertSame('b_', $innerAt2->get('b'));
+
+        $innerAt4 = $map->get(4);
+        self::assertCount(2, $innerAt4);
+        self::assertSame('c_', $innerAt4->get('c'));
+        self::assertSame('d_', $innerAt4->get('d'));
     }
 
     public function testMappedQueuesFromIterable(): void


### PR DESCRIPTION
## Summary
- Add `mappedMapsFromIterable()` that groups iterable into `Map<K, Map<KInner, V>>`, analogous to existing `mappedSetsFromIterable` and `mappedQueuesFromIterable`
- Add test covering grouping and inner key/value mapping

## Test plan
- [x] `vendor/bin/phpunit tests/DsTest.php` — 7 tests, 25 assertions pass
- [x] `vendor/bin/phpstan` — no errors
- [x] `vendor/bin/phpcs` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)