### PR TITLE
Add PHP 8.5 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         php-version:
           - "8.3"
           - "8.4"
+          - "8.5"
         dependencies:
           - "highest"
         include:


### PR DESCRIPTION
## Summary
This change extends the CI/CD pipeline to test against PHP 8.5, ensuring compatibility with the latest PHP version.

## Key Changes
- Added PHP 8.5 to the test matrix in the GitHub Actions CI workflow alongside existing PHP 8.3 and 8.4 versions

## Details
The CI workflow now tests the codebase against three PHP versions (8.3, 8.4, and 8.5) with both highest and lowest dependency configurations, helping to catch any compatibility issues early with the latest PHP release.

https://claude.ai/code/session_01Td3nn1rF9oyYYkz6Zw8pTv