### PR TITLE
Add mappedVectorsFromIterable helper

### DIFF
--- a/src/ds.php
+++ b/src/ds.php
@@ -118,6 +118,37 @@ function mappedSetsFromIterable(iterable $iterable, callable $mapper): Map
 
 /**
  * @param iterable<K, V> $iterable
+ * @param callable(K, V): Pair<KReturn, VReturn> $mapper
+ *
+ * @return Map<KReturn, Vector<VReturn>>
+ *
+ * @template K
+ * @template V
+ * @template KReturn
+ * @template VReturn
+ */
+function mappedVectorsFromIterable(iterable $iterable, callable $mapper): Map
+{
+    /** @var Map<KReturn, Vector<VReturn>> $map */
+    $map = new Map();
+
+    foreach ($iterable as $key => $value) {
+        $keyValue = $mapper($key, $value);
+        $vector = $map->get($keyValue->key, null);
+        if ($vector === null) {
+            /** @var Vector<VReturn> $vector */
+            $vector = new Vector();
+            $map->put($keyValue->key, $vector);
+        }
+
+        $vector->push($keyValue->value);
+    }
+
+    return $map;
+}
+
+/**
+ * @param iterable<K, V> $iterable
  * @param callable(K,V): VReturn $mapper
  *
  * @return Set<VReturn>

--- a/tests/DsTest.php
+++ b/tests/DsTest.php
@@ -13,12 +13,14 @@ use function Cdn77\Functions\mapFromEntries;
 use function Cdn77\Functions\mapFromIterable;
 use function Cdn77\Functions\mappedQueuesFromIterable;
 use function Cdn77\Functions\mappedSetsFromIterable;
+use function Cdn77\Functions\mappedVectorsFromIterable;
 use function Cdn77\Functions\setFromIterable;
 use function Cdn77\Functions\vectorFromIterable;
 
 #[CoversFunction('Cdn77\Functions\mapFromIterable')]
 #[CoversFunction('Cdn77\Functions\mappedQueuesFromIterable')]
 #[CoversFunction('Cdn77\Functions\mappedSetsFromIterable')]
+#[CoversFunction('Cdn77\Functions\mappedVectorsFromIterable')]
 #[CoversFunction('Cdn77\Functions\setFromIterable')]
 #[CoversFunction('Cdn77\Functions\vectorFromIterable')]
 final class DsTest extends TestCase
@@ -64,7 +66,12 @@ final class DsTest extends TestCase
 
         $map = mappedQueuesFromIterable(
             $iterableFactory(),
-            static fn (int $key, string $value) => new Pair($key * 2, $value . '_'),
+            static function (int $key, string $value): Pair {
+                /** @phpstan-var non-falsy-string $mappedValue */
+                $mappedValue = $value . '_';
+
+                return new Pair($key * 2, $mappedValue);
+            },
         );
 
         self::assertCount(2, $map);
@@ -89,12 +96,41 @@ final class DsTest extends TestCase
 
         $map = mappedSetsFromIterable(
             $iterableFactory(),
-            static fn (int $key, string $value) => new Pair($key * 2, $value . '_'),
+            static function (int $key, string $value): Pair {
+                /** @phpstan-var non-falsy-string $mappedValue */
+                $mappedValue = $value . '_';
+
+                return new Pair($key * 2, $mappedValue);
+            },
         );
 
         self::assertCount(2, $map);
         self::assertTrue($map->get(2)->contains('a_', 'b_'));
         self::assertTrue($map->get(4)->contains('a_', 'b_'));
+    }
+
+    public function testMappedVectorsFromIterable(): void
+    {
+        $iterableFactory = static function (): Generator {
+            yield 1 => 'a';
+            yield 1 => 'b';
+            yield 2 => 'c';
+            yield 2 => 'd';
+        };
+
+        $map = mappedVectorsFromIterable(
+            $iterableFactory(),
+            static function (int $key, string $value): Pair {
+                /** @phpstan-var non-falsy-string $mappedValue */
+                $mappedValue = $value . '_';
+
+                return new Pair($key * 2, $mappedValue);
+            },
+        );
+
+        self::assertCount(2, $map);
+        self::assertSame(['a_', 'b_'], $map->get(2)->toArray());
+        self::assertSame(['c_', 'd_'], $map->get(4)->toArray());
     }
 
     public function testSetFromIterable(): void


### PR DESCRIPTION
## Summary
- add `mappedVectorsFromIterable()` to group mapped values into `Ds\\Vector` instances by key
- cover the new helper in `DsTest` and tighten mapped collection test callbacks to satisfy static analysis
- verify the change with `vendor/bin/phpunit` and `vendor/bin/phpstan analyse`