### PR TITLE
chore: require PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,13 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.3"
           - "8.4"
           - "8.5"
         dependencies:
           - "highest"
         include:
           - dependencies: "lowest"
-            php-version: "8.3"
+            php-version: "8.4"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           coverage: "none"
           extensions: "ds, mbstring"
           tools: "cs2pr"
@@ -41,7 +41,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           coverage: "none"
           extensions: "ds, mbstring"
           tools: "cs2pr"

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           coverage: "pcov"
           extensions: "ds, mbstring"
           tools: "cs2pr"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           coverage: "none"
           extensions: "ds, mbstring"
           tools: "cs2pr"
@@ -41,7 +41,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           coverage: "none"
           extensions: "ds, mbstring"
           tools: "cs2pr"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "ext-ds": "*"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- raise the library's minimum supported PHP version from 8.3 to 8.4 in `composer.json`
- move CI jobs and the lowest-dependency test leg to PHP 8.4 so the baseline matches the package requirement
- keep the broader CI matrix coverage on newer PHP versions unchanged