### PR TITLE
fix: preserve assert_return generic type

### DIFF
--- a/src/assert.php
+++ b/src/assert.php
@@ -9,8 +9,10 @@ use Throwable;
 use function assert;
 
 /**
- * @param TValue $assertionFn
+ * @param TValue $value
  * @param callable(TValue):(bool|string) $assertionFn
+ *
+ * @return TValue
  *
  * @template TValue
  */


### PR DESCRIPTION
## Summary
- fix the assert_return phpdoc generic contract so static analysis preserves TValue
- keep the runtime behavior unchanged while making phpstan infer the returned asserted type