### PR TITLE
ci: restrict push workflows to numeric release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "*.*.x"
+      - "[0-9]*.[0-9]*.x"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "*.*.x"
+      - "[0-9]*.[0-9]*.x"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "*.*.x"
+      - "[0-9]*.[0-9]*.x"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "*.*.x"
+      - "[0-9]*.[0-9]*.x"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- tighten workflow `push` branch filters from `*.*.x` to `[0-9]*.[0-9]*.x`
- keep push-triggered workflows limited to numeric release branches such as `0.3.x` and `1.2.x`
- apply the same trigger fix consistently across all GitHub Actions workflows