### PR TITLE
feat(ds): add map mutation helpers

### DIFF
--- a/src/ds_map.php
+++ b/src/ds_map.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cdn77\Functions;
+
+use Ds\Map;
+
+/**
+ * @param Map<K, V> $map
+ * @param K $key
+ * @param V $value
+ *
+ * @return V
+ *
+ * @template K
+ * @template V
+ */
+function mapPutIfAbsent(Map $map, mixed $key, mixed $value): mixed
+{
+    if ($map->hasKey($key)) {
+        return $map->get($key);
+    }
+
+    $map->put($key, $value);
+
+    return $value;
+}
+
+/**
+ * A null computed value removes the key, matching Java Map compute semantics.
+ *
+ * @param Map<K, V> $map
+ * @param K $key
+ * @param callable(K, V|null): (V|null) $computer
+ *
+ * @return V|null
+ *
+ * @template K
+ * @template V
+ */
+function mapCompute(Map $map, mixed $key, callable $computer): mixed
+{
+    $hasKey = $map->hasKey($key);
+    $computedValue = $computer($key, $hasKey ? $map->get($key) : null);
+
+    if ($computedValue === null) {
+        if ($hasKey) {
+            $map->remove($key);
+        }
+
+        return null;
+    }
+
+    $map->put($key, $computedValue);
+
+    return $computedValue;
+}
+
+/**
+ * A null computed value leaves the key absent, matching Java Map computeIfAbsent semantics.
+ *
+ * @param Map<K, V> $map
+ * @param K $key
+ * @param callable(K): (V|null) $computer
+ *
+ * @return V|null
+ *
+ * @template K
+ * @template V
+ */
+function mapComputeIfAbsent(Map $map, mixed $key, callable $computer): mixed
+{
+    if ($map->hasKey($key)) {
+        return $map->get($key);
+    }
+
+    $computedValue = $computer($key);
+    if ($computedValue === null) {
+        return null;
+    }
+
+    $map->put($key, $computedValue);
+
+    return $computedValue;
+}
+
+/**
+ * A null computed value removes the key, matching Java Map computeIfPresent semantics.
+ *
+ * @param Map<K, V> $map
+ * @param K $key
+ * @param callable(K, V): (V|null) $computer
+ *
+ * @return V|null
+ *
+ * @template K
+ * @template V
+ */
+function mapComputeIfPresent(Map $map, mixed $key, callable $computer): mixed
+{
+    if (! $map->hasKey($key)) {
+        return null;
+    }
+
+    $computedValue = $computer($key, $map->get($key));
+    if ($computedValue === null) {
+        $map->remove($key);
+
+        return null;
+    }
+
+    $map->put($key, $computedValue);
+
+    return $computedValue;
+}

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -5,5 +5,6 @@ declare(strict_types=1);
 require_once __DIR__ . '/absurd.php';
 require_once __DIR__ . '/assert.php';
 require_once __DIR__ . '/ds.php';
+require_once __DIR__ . '/ds_map.php';
 require_once __DIR__ . '/generator.php';
 require_once __DIR__ . '/noop.php';

--- a/tests/DsTest.php
+++ b/tests/DsTest.php
@@ -4,21 +4,30 @@ declare(strict_types=1);
 
 namespace Cdn77\Functions\Tests;
 
+use Ds\Map;
 use Ds\Pair;
 use Generator;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+use function Cdn77\Functions\mapCompute;
+use function Cdn77\Functions\mapComputeIfAbsent;
+use function Cdn77\Functions\mapComputeIfPresent;
 use function Cdn77\Functions\mapFromEntries;
 use function Cdn77\Functions\mapFromIterable;
 use function Cdn77\Functions\mappedMapsFromIterable;
 use function Cdn77\Functions\mappedQueuesFromIterable;
 use function Cdn77\Functions\mappedSetsFromIterable;
 use function Cdn77\Functions\mappedVectorsFromIterable;
+use function Cdn77\Functions\mapPutIfAbsent;
 use function Cdn77\Functions\setFromIterable;
 use function Cdn77\Functions\vectorFromIterable;
 
+#[CoversFunction('Cdn77\Functions\mapCompute')]
+#[CoversFunction('Cdn77\Functions\mapComputeIfAbsent')]
+#[CoversFunction('Cdn77\Functions\mapComputeIfPresent')]
 #[CoversFunction('Cdn77\Functions\mapFromIterable')]
+#[CoversFunction('Cdn77\Functions\mapPutIfAbsent')]
 #[CoversFunction('Cdn77\Functions\mappedMapsFromIterable')]
 #[CoversFunction('Cdn77\Functions\mappedQueuesFromIterable')]
 #[CoversFunction('Cdn77\Functions\mappedSetsFromIterable')]
@@ -27,6 +36,71 @@ use function Cdn77\Functions\vectorFromIterable;
 #[CoversFunction('Cdn77\Functions\vectorFromIterable')]
 final class DsTest extends TestCase
 {
+    public function testMapCompute(): void
+    {
+        /** @var Map<string, mixed> $map */
+        $map = new Map(['a' => 1]);
+
+        $computedValue = mapCompute($map, 'a', static function (string $_, mixed $value): int {
+            self::assertIsInt($value);
+
+            return $value + 1;
+        });
+        $insertedValue = mapCompute($map, 'b', static function (string $_, mixed $value): int {
+            self::assertNull($value);
+
+            return 3;
+        });
+        $removedValue = mapCompute($map, 'a', static function (string $_, mixed $value): null {
+            self::assertSame(2, $value);
+
+            return null;
+        });
+
+        self::assertSame(2, $computedValue);
+        self::assertSame(3, $insertedValue);
+        self::assertNull($removedValue);
+        self::assertFalse($map->hasKey('a'));
+        self::assertSame(3, $map->get('b'));
+    }
+
+    public function testMapComputeIfAbsent(): void
+    {
+        /** @var Map<string, int|null> $map */
+        $map = new Map(['a' => 1]);
+
+        $existingValue = mapComputeIfAbsent($map, 'a', static fn (): int => 2);
+        $computedValue = mapComputeIfAbsent($map, 'b', static fn (): int => 3);
+        $nullValue = mapComputeIfAbsent($map, 'c', static fn (): null => null);
+
+        self::assertSame(1, $existingValue);
+        self::assertSame(3, $computedValue);
+        self::assertNull($nullValue);
+        self::assertSame(1, $map->get('a'));
+        self::assertSame(3, $map->get('b'));
+        self::assertFalse($map->hasKey('c'));
+    }
+
+    public function testMapComputeIfPresent(): void
+    {
+        /** @var Map<string, int> $map */
+        $map = new Map(['a' => 1, 'b' => 2]);
+
+        $missingValue = mapComputeIfPresent($map, 'c', static fn (): int => 3);
+        $computedValue = mapComputeIfPresent($map, 'a', static fn (string $_, int $value): int => $value + 1);
+        $removedValue = mapComputeIfPresent(
+            $map,
+            'b',
+            static fn (string $_, int $value): int|null => $value === 2 ? null : $value,
+        );
+
+        self::assertNull($missingValue);
+        self::assertSame(2, $computedValue);
+        self::assertNull($removedValue);
+        self::assertSame(2, $map->get('a'));
+        self::assertFalse($map->hasKey('b'));
+    }
+
     public function testMapFromEntries(): void
     {
         $iterableFactory = static function (): Generator {
@@ -55,6 +129,20 @@ final class DsTest extends TestCase
         self::assertCount(2, $map);
         self::assertNull($map->get(1, null));
         self::assertFalse($map->get(4));
+    }
+
+    public function testMapPutIfAbsent(): void
+    {
+        /** @var Map<string, int> $map */
+        $map = new Map(['a' => 1]);
+
+        $existingValue = mapPutIfAbsent($map, 'a', 2);
+        $insertedValue = mapPutIfAbsent($map, 'b', 3);
+
+        self::assertSame(1, $existingValue);
+        self::assertSame(3, $insertedValue);
+        self::assertSame(1, $map->get('a'));
+        self::assertSame(3, $map->get('b'));
     }
 
     public function testMappedMapsFromIterable(): void


### PR DESCRIPTION
Adds Java-style Ds\Map mutation helpers: mapPutIfAbsent(), mapCompute(), mapComputeIfAbsent(), and mapComputeIfPresent().

The compute helpers mutate the provided map and use null computed values for the Java-style remove/do-not-add semantics.