### PR TITLE
chore(ds): require ext-ds v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          extensions: "ds, mbstring"
+          extensions: "ds-1.8.0, mbstring"
           ini-values: "zend.assertions=1"
 
       - name: "Install dependencies with Composer"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: "8.4"
           coverage: "none"
-          extensions: "ds, mbstring"
+          extensions: "ds-1.8.0, mbstring"
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
@@ -43,7 +43,7 @@ jobs:
         with:
           php-version: "8.4"
           coverage: "none"
-          extensions: "ds, mbstring"
+          extensions: "ds-1.8.0, mbstring"
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           php-version: "8.4"
           coverage: "pcov"
-          extensions: "ds, mbstring"
+          extensions: "ds-1.8.0, mbstring"
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: "8.4"
           coverage: "none"
-          extensions: "ds, mbstring"
+          extensions: "ds-1.8.0, mbstring"
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
@@ -43,7 +43,7 @@ jobs:
         with:
           php-version: "8.4"
           coverage: "none"
-          extensions: "ds, mbstring"
+          extensions: "ds-1.8.0, mbstring"
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,12 @@
     ],
     "require": {
         "php": "^8.4",
-        "ext-ds": "*"
+        "ext-ds": "^1"
     },
     "require-dev": {
         "cdn77/coding-standard": "^7.0",
         "ergebnis/composer-normalize": "^2.23",
         "infection/infection": "^0.32.0",
-        "php-ds/php-ds": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0.0",


### PR DESCRIPTION
## Summary
- Require ext-ds v1 in Composer
- Install ds-1.8.0 in GitHub Actions instead of the floating latest release
- Remove the php-ds polyfill dev dependency so dev installs require the native extension